### PR TITLE
Fix: footer table

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1,7 +1,12 @@
 /* common */
 body {
   margin: 0;
+  width: 100%;
+}
+
+.wrapper {
   overflow-x: hidden;
+  overflow-y: hidden;
 }
 
 header {
@@ -25,6 +30,27 @@ main section p {
 
 table {
   font-family: sans-serif;
+  margin: 2em 0;
+  width: 100%;
+  border-spacing: 0;
+  border-collapse: collapse;
+}
+
+tr {
+  padding: 0;
+  border-bottom: solid 1px #1f1f1f;
+  height: 4em;
+  vertical-align: bottom;
+}
+
+th {
+  padding: 0;
+  text-align: left;
+  width: 50%;
+}
+
+td {
+  padding: 0;
 }
 
 footer {
@@ -104,28 +130,15 @@ footer p {
   }
 
   table {
-    font-family: sans-serif;
     font-size: 20px;
-    width: 100%;
-    border-collapse: collapse;
-  }
-
-  th {
-    text-align: left;
-    width: 50%;
-  }
-
-  tr {
-    border-bottom: solid 1px #000000;
-    height: 4em;
-    vertical-align: bottom;
-  }
-
-  tr td .last {
-    border: 0px none;
   }
 
   footer {
+    height: 150px;
+    text-align: center;
+  }
+
+  footer p {
     line-height: 150px;
   }
 
@@ -251,38 +264,17 @@ footer p {
     font-size: 18px;
   }
 
-  table {
-    width: 100%;
-    margin-top: 2em;
-    table-layout: fixed;
-    font-size: 15px;
-    border-collapse: collapse;
-  }
-
-  tr td {
-    border-bottom: solid 1px #1f1f1f;
-    height: 4em;
-    vertical-align: bottom;
-  }
-
-  tr th {
-    border-bottom: solid 1px #1f1f1f;
-    text-align: left;
-    height: 2em;
-  }
-
   footer {
-    height: 100px;
-    vertical-align: middle;
+    height: 130px;
+    position: relative;
   }
 
   footer p {
-    /* position: absolute;
-    top: 0;
-    right: 0;
-    left: 0;
-    bottom: 0;
-    margin: auto; */
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translateY(-50%) translateX(-50%);
+    -webkit-transform: translateY(-50%) translateX(-50%);
   }
 
 
@@ -336,6 +328,13 @@ footer p {
 
   table {
     font-size: 18px;
-    width: 100%;
+  }
+
+  footer {
+    height: 100px;
+  }
+
+  footer p {
+    line-height: 100px;
   }
 }

--- a/index.html
+++ b/index.html
@@ -11,85 +11,86 @@
 </head>
 
 <body>
-  <header>
-    <div class="container">
-      <div class="box"></div>
-      <h1>藤谷　佳正</h1>
-      <div class="toggle">
-        <div id="show">
-          <div class="one"></div>
-          <div class="two"></div>
-          <div class="three"></div>
+  <div class="wrapper">
+    <header>
+      <div class="container">
+        <div class="box"></div>
+        <h1>藤谷　佳正</h1>
+        <div class="toggle">
+          <div id="show">
+            <div class="one"></div>
+            <div class="two"></div>
+            <div class="three"></div>
+          </div>
         </div>
+        <ul id="nav">
+          <li><a href="#about">事業内容</a></li>
+          <li><a href="#work">実績紹介</a></li>
+          <li><a href="#price">料金例</a></li>
+          <li><a href="">お問い合わせ</a></li>
+        </ul>
       </div>
-      <ul id="nav">
-        <li><a href="#about">事業内容</a></li>
-        <li><a href="#work">実績紹介</a></li>
-        <li><a href="#price">料金例</a></li>
-        <li><a href="">お問い合わせ</a></li>
-      </ul>
-    </div>
-  </header>
+    </header>
 
-  <main>
-    <section>
-      <h1 id="about">事業内容</h1>
-      <p>そのころわたくしは、モリーオ市の博物局に勤めて居りました。
-        　十八等官でしたから役所のなかでも、ずうっと下の方でしたし俸給ほうきゅうもほんのわずかでしたが、受持ちが標本の採集や整理で生れ付き好きなことでしたから、わたくしは毎日ずいぶん愉快にはたらきました。殊にそのころ、モリーオ市では競馬場を植物園に拵こしらえ直すというので、その景色のいいまわりにアカシヤを植え込んだ広い地面が、切符売場や信号所の建物のついたまま、わたくしどもの役所の方へまわって来たものですから、わたくしはすぐ宿直という名前で月賦で買った小さな蓄音器と二十枚ばかりのレコードをもって、その番小屋にひとり住むことになりました。わたくしはそこの馬を置く場所に板で小さなしきいをつけて一疋の山羊を飼いました。毎朝その乳をしぼってつめたいパンをひたしてたべ、それから黒い革のかばんへすこしの書類や雑誌を入れ、靴もきれいにみがき、並木のポプラの影法師を大股にわたって市の役所へ出て行くのでした。</p>
+    <main>
+      <section>
+        <h1 id="about">事業内容</h1>
+        <p>そのころわたくしは、モリーオ市の博物局に勤めて居りました。
+          　十八等官でしたから役所のなかでも、ずうっと下の方でしたし俸給ほうきゅうもほんのわずかでしたが、受持ちが標本の採集や整理で生れ付き好きなことでしたから、わたくしは毎日ずいぶん愉快にはたらきました。殊にそのころ、モリーオ市では競馬場を植物園に拵こしらえ直すというので、その景色のいいまわりにアカシヤを植え込んだ広い地面が、切符売場や信号所の建物のついたまま、わたくしどもの役所の方へまわって来たものですから、わたくしはすぐ宿直という名前で月賦で買った小さな蓄音器と二十枚ばかりのレコードをもって、その番小屋にひとり住むことになりました。わたくしはそこの馬を置く場所に板で小さなしきいをつけて一疋の山羊を飼いました。毎朝その乳をしぼってつめたいパンをひたしてたべ、それから黒い革のかばんへすこしの書類や雑誌を入れ、靴もきれいにみがき、並木のポプラの影法師を大股にわたって市の役所へ出て行くのでした。</p>
+      </section>
 
-    </section>
+      <section>
+        <h1 id="work">実績紹介</h1>
+        <p>そのころわたくしは、モリーオ市の博物局に勤めて居りました。
+          十八等官でしたから役所のなかでも、ずうっと下の方でしたし俸給ほうきゅうもほんのわずかでしたが、受持ちが標本の採集や整理で生れ付き好きなことでしたから、わたくしは毎日ずいぶん愉快にはたらきました。殊にそのころ、モリーオ市では競馬場を植物園に拵こしらえ直すというので、その景色のいいまわりにアカシヤを植え込んだ広い地面が、切符売場や信号所の建物のついたまま、わたくしどもの役所の方へまわって来たものですから、わたくしはすぐ宿直という名前で月賦で買った小さな蓄音器と二十枚ばかりのレコードをもって、その番小屋にひとり住むことになりました。わたくしはそこの馬を置く場所に板で小さなしきいをつけて一疋の山羊を飼いました。毎朝その乳をしぼってつめたいパンをひたしてたべ、それから黒い革のかばんへすこしの書類や雑誌を入れ、靴もきれいにみがき、並木のポプラの影法師を大股にわたって市の役所へ出て行くのでした。</p>
+      </section>
 
-    <section>
-      <h1 id="work">実績紹介</h1>
-      <p>そのころわたくしは、モリーオ市の博物局に勤めて居りました。
-        十八等官でしたから役所のなかでも、ずうっと下の方でしたし俸給ほうきゅうもほんのわずかでしたが、受持ちが標本の採集や整理で生れ付き好きなことでしたから、わたくしは毎日ずいぶん愉快にはたらきました。殊にそのころ、モリーオ市では競馬場を植物園に拵こしらえ直すというので、その景色のいいまわりにアカシヤを植え込んだ広い地面が、切符売場や信号所の建物のついたまま、わたくしどもの役所の方へまわって来たものですから、わたくしはすぐ宿直という名前で月賦で買った小さな蓄音器と二十枚ばかりのレコードをもって、その番小屋にひとり住むことになりました。わたくしはそこの馬を置く場所に板で小さなしきいをつけて一疋の山羊を飼いました。毎朝その乳をしぼってつめたいパンをひたしてたべ、それから黒い革のかばんへすこしの書類や雑誌を入れ、靴もきれいにみがき、並木のポプラの影法師を大股にわたって市の役所へ出て行くのでした。</p>
-    </section>
+      <section>
+        <h1 id="price">料金例</h1>
 
-    <section>
-      <h1 id="price">料金例</h1>
+        <table>
+          <tr>
+            <th scope="col">制作内容</th>
+            <th scope="col">費用の相場</th>
+          </tr>
+          <tr>
+            <td>WEBサイト構築<br />(テンプレートデザインでの制作)</td>
+            <td>３〜１０万円</td>
+          </tr>
+          <tr>
+            <td>WEBサイト構築<br />(テンプレートをカスタマイズ)</td>
+            <td>２０〜３０万円</td>
+          </tr>
+          <tr>
+            <td>Wordpress設置</td>
+            <td>３万円〜</td>
+          </tr>
+          <tr>
+            <td>独自システムの構築</td>
+            <td>１００万円〜</td>
+          </tr>
+          <tr>
+            <td class="last"></td>
+            <td class="last"></td>
+          </tr>
+        </table>
+      </section>
+    </main>
+    <footer>
+      <p>COPYRIGHT &#169; 2020<br class="sp_br" /> YOSHIMASA FUJITANI ALL RIGHTS RESERVED.</p>
+    </footer>
+    <script>
+      'use strict';
 
-      <table>
-        <tr>
-          <th scope="col">制作内容</th>
-          <th scope="col">費用の相場</th>
-        </tr>
-        <tr>
-          <td>WEBサイト構築<br />(テンプレートデザインでの制作)</td>
-          <td>３〜１０万円</td>
-        </tr>
-        <tr>
-          <td>WEBサイト構築<br />(テンプレートをカスタマイズ)</td>
-          <td>２０〜３０万円</td>
-        </tr>
-        <tr>
-          <td>Wordpress設置</td>
-          <td>３万円〜</td>
-        </tr>
-        <tr>
-          <td>独自システムの構築</td>
-          <td>１００万円〜</td>
-        </tr>
-        <tr>
-          <td class="last"></td>
-          <td class="last"></td>
-        </tr>
-      </table>
-    </section>
-  </main>
-  <footer>
-    <p>COPYRIGHT &#169; 2020<br class="sp_br" />   YOSHIMASA FUJITANI ALL RIGHTS RESERVED.</p>
-  </footer>
-  <script>
-    'use strict';
+      const show = document.getElementById('show');
+      const nav = document.getElementById('nav');
 
-    const show = document.getElementById('show');
-    const nav = document.getElementById('nav');
-
-    show.addEventListener('click', () => {
-      show.classList.toggle('on');
-      nav.classList.toggle('open');
-    });
-  </script>
+      show.addEventListener('click', () => {
+        show.classList.toggle('on');
+        nav.classList.toggle('open');
+      });
+    </script>
+  </div>
 </body>
 
 </html>


### PR DESCRIPTION
-overflow-x, yを効かせるためにbody直下にコンテンツ全部を包むwrapperを作ったので、コードが1行ずれました。
header, main section, scriptの内容は変更ありません。

-footerのコピーライトを上下左右中央配置に修正しました。
　small-screen のfooter heightを、css 268行で修正しました。

-tableのstyleのコードが重複していたので、css 31〜54行にまとめました。
 tableのborderが太くなる問題は未解決です。調べています。

この後、ブランチを切って、mainのフォントを試していきます。
