### PR TITLE
Change: header, mainのフォント

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -12,15 +12,19 @@ body {
 header {
   background: #00c8f8;
   color: #ffffff;
-  font-family: "Sawarabi Mincho";
+  font-family: "Sawarabi Mincho", "serif";
+}
+
+main {
+  color: #1f1f1f;
 }
 
 main section h1 {
-  font-family: "Sawarabi Mincho";
+  font-family: "Sawarabi Mincho", "serif";
 }
 
 main section p {
-  font-family: sans-serif;
+  font-family: "YuGothic", "sans-serif";
   margin-top: 1em;
   margin-left: auto;
   margin-right: auto;
@@ -29,16 +33,17 @@ main section p {
 }
 
 table {
-  font-family: sans-serif;
+  font-family: "YuGothic", "sans-serif";
   margin: 2em 0;
   width: 100%;
   border-spacing: 0;
   border-collapse: collapse;
+  border-color: #1f1f1f;
 }
 
 tr {
   padding: 0;
-  border-bottom: solid 1px #1f1f1f;
+  border-bottom: solid 1px;
   height: 4em;
   vertical-align: bottom;
 }
@@ -57,7 +62,10 @@ footer {
   background: #00c8f8;
   color: #ffffff;
   text-align: center;
-  font-family: "Sawarabi Mincho";
+  font-family: "Sawarabi Mincho", "serif";
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 footer p {
@@ -122,7 +130,6 @@ footer p {
     font-family: "Sawarabi Mincho";
     margin: 0;
     font-size: 24px;
-    color: #1f1f1f;
   }
 
   main section p {
@@ -135,11 +142,6 @@ footer p {
 
   footer {
     height: 150px;
-    text-align: center;
-  }
-
-  footer p {
-    line-height: 150px;
   }
 
   .sp_br {
@@ -230,6 +232,7 @@ footer p {
     top: 0;
     right: -160px;
     transition: 0.4s;
+    line-height: 2.5;
   }
 
   header ul li {
@@ -266,18 +269,7 @@ footer p {
 
   footer {
     height: 130px;
-    position: relative;
   }
-
-  footer p {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translateY(-50%) translateX(-50%);
-    -webkit-transform: translateY(-50%) translateX(-50%);
-  }
-
-
 
 }
 
@@ -318,12 +310,10 @@ footer p {
   main section h1 {
     margin: 0;
     font-size: 24px;
-    color: #1f1f1f;
   }
 
   main section p {
     font-size: 18px;
-    line-height: 2.0;
   }
 
   table {
@@ -334,7 +324,4 @@ footer p {
     height: 100px;
   }
 
-  footer p {
-    line-height: 100px;
-  }
 }

--- a/index.html
+++ b/index.html
@@ -77,7 +77,7 @@
       </section>
     </main>
     <footer>
-      <p>COPYRIGHT &#169; 2020<br class="sp_br" /> YOSHIMASA FUJITANI ALL RIGHTS RESERVED.</p>
+      <p>COPYRIGHT &#169; 2020<br class="sp_br" /> YOSHIMASA FUJITANI<br class="sp_br" /> ALL RIGHTS RESERVED.</p>
     </footer>
     <script>
       'use strict';


### PR DESCRIPTION
（-#6のpullrequestに  wrapperについての回答してあります。）

以下、今回の内容
-見出し、navをSawarabi明朝　×　メインの中身は遊ゴシック

-Footerのコピーライト上下左右中央配置にするためのコードを短く修正。

-スマホ画面のFooter のコピーライトの改行位置修正。

-スマホ画面のnavにも行間を設定。
